### PR TITLE
fix error when plugin is called before runApp()

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'contact_page.dart';
 import 'models/contact.dart';
 
 void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   final appDocumentDirectory =
       await path_provider.getApplicationDocumentsDirectory();
   Hive.init(appDocumentDirectory.path);


### PR DESCRIPTION
Called `WidgetsFlutterBinding.ensureInitialized()` before using the path_provider plugin in main.dart. By doing this, we prevent the following error: ServicesBinding.defaultBinaryMessenger was accessed before the binding was initialized.